### PR TITLE
fix: issue #10 - when receiveing conflict responses retry

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -462,7 +462,7 @@ wcwidth = "*"
 [[package]]
 category = "dev"
 description = "Run a subprocess in a pseudo terminal"
-marker = "python_version == \"3.6\" and sys_platform != \"win32\" or python_version > \"3.6\" and sys_platform != \"win32\""
+marker = "python_version == \"3.6\" and sys_platform != \"win32\" and (python_version == \"3.6\" and sys_platform != \"win32\" or python_version > \"3.6\" and sys_platform != \"win32\") or python_version > \"3.6\" and sys_platform != \"win32\" and (python_version == \"3.6\" and sys_platform != \"win32\" or python_version > \"3.6\" and sys_platform != \"win32\")"
 name = "ptyprocess"
 optional = false
 python-versions = "*"
@@ -626,6 +626,17 @@ version = "5.0.0"
 
 [[package]]
 category = "main"
+description = "Retry code until it succeeds"
+name = "tenacity"
+optional = false
+python-versions = ">=3.6"
+version = "8.0.1"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
+category = "main"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
@@ -634,20 +645,8 @@ version = "0.10.2"
 
 [[package]]
 category = "dev"
-description = "Traitlets Python configuration system"
-marker = "python_version > \"3.6\""
-name = "traitlets"
-optional = false
-python-versions = ">=3.7"
-version = "5.1.1"
-
-[package.extras]
-test = ["pytest"]
-
-[[package]]
-category = "dev"
 description = "Traitlets Python config system"
-marker = "python_version == \"3.6\""
+marker = "python_version == \"3.6\" or python_version > \"3.6\""
 name = "traitlets"
 optional = false
 python-versions = "*"
@@ -729,7 +728,7 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "6b9762a5140d4889a48530a86836523693b34dbf30489a9eb9c8427d1e89084e"
+content-hash = "6f436954d6b06878d16f16d7d61409affc91001f30de5da550b344e5b3045935"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -973,13 +972,15 @@ smmap = [
     {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
+tenacity = [
+    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
+    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 traitlets = [
-    {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
-    {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
     {file = "traitlets-4.3.3.tar.gz", hash = "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ gitpython = "^3.1.14"
 kubernetes = "^12.0.1"
 click = "^7"
 toml = "^0.10.2"
+tenacity = "^8.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
When receiveing conflict responses from the kubernetes API retry the patch a few times. 

In addition, try to "uncrash" pending containers by lowering requested (minimum) resources and increasing resource limits